### PR TITLE
Refactor CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests.cpp.StarterProject)
 
-set(CMAKE_CXX_STANDARD 17)
-include_directories(lib)
-
 enable_testing()
 add_subdirectory(code)
+add_subdirectory(lib)
 add_subdirectory(tests)
 
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.8)
-project(StarterProject.code CXX)
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME}
-        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+add_library(StarterProject.code INTERFACE)
+
+target_include_directories(StarterProject.code
+        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(TARGET StarterProject.code PROPERTY CXX_STANDARD 17)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(StarterProject.lib INTERFACE)
+
+target_include_directories(StarterProject.lib
+        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(TARGET StarterProject.lib PROPERTY CXX_STANDARD 17)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,12 @@
-cmake_minimum_required(VERSION 3.8)
-project(StarterProject.tests)
-set(CMAKE_CXX_STANDARD 17)
 set(SOURCE_FILES
         main.cpp
 		DemoTest.cpp
         NewTest.cpp)
+
 add_executable(StarterProject.tests ${SOURCE_FILES} )
+
+target_link_libraries(StarterProject.tests StarterProject.code StarterProject.lib)
+
+set(TARGET StarterProject.tests PROPERTY CXX_STANDARD 17)
+
 add_test(NAME StarterProject.tests COMMAND StarterProject.tests)


### PR DESCRIPTION
Hi!

Great project! :)

I have created a proposal on how to refactor CMakeLists.txt files in order to follow how I understand so called "Modern CMake" guidelines:
* Set dependencies and properties on targets directly using e.g. target_link_libraries
* Avoid setting global settings through e.g. include_directories

I have done the following changes:
* Set project name and minimum CMake version in the top CMakelists.txt file only
* Add subdirectory lib using add_subdirectoy instead of via include_directories
* Add a CMakeLists.txt file to lib folder
* Use command target_link_libraries in the tests folder to link tests with 
libraries defined in the code and lib folders
* Set C++17 standard on the defined targets instead of as a general variable

Best regards,
Jacob