### PR TITLE
Revert "Refactor CMakeLists.txt files"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests.cpp.StarterProject)
 
+set(CMAKE_CXX_STANDARD 17)
+include_directories(lib)
+
 enable_testing()
 add_subdirectory(code)
-add_subdirectory(lib)
 add_subdirectory(tests)
 
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,6 +1,5 @@
-add_library(StarterProject.code INTERFACE)
-
-target_include_directories(StarterProject.code
-        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(TARGET StarterProject.code PROPERTY CXX_STANDARD 17)
+cmake_minimum_required(VERSION 3.8)
+project(StarterProject.code CXX)
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME}
+        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,0 @@
-add_library(StarterProject.lib INTERFACE)
-
-target_include_directories(StarterProject.lib
-        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(TARGET StarterProject.lib PROPERTY CXX_STANDARD 17)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(StarterProject.tests)
+set(CMAKE_CXX_STANDARD 17)
 set(SOURCE_FILES
         main.cpp
 		DemoTest.cpp
         NewTest.cpp)
-
 add_executable(StarterProject.tests ${SOURCE_FILES} )
-
-target_link_libraries(StarterProject.tests StarterProject.code StarterProject.lib)
-
-set(TARGET StarterProject.tests PROPERTY CXX_STANDARD 17)
-
 add_test(NAME StarterProject.tests COMMAND StarterProject.tests)


### PR DESCRIPTION
Reverts approvals/ApprovalTests.cpp.StarterProject#3

Temporarily reverting, as we didn't spot before merging that this change that it broke the linux builds:
https://travis-ci.org/approvals/ApprovalTests.cpp.StarterProject/builds/552962894