### PR TITLE
Refactor CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests.cpp.StarterProject)
 
 set(CMAKE_CXX_STANDARD 17)
-include_directories(lib)
 
 enable_testing()
 add_subdirectory(code)
+add_subdirectory(lib)
 add_subdirectory(tests)
 
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-project(StarterProject.code CXX)
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME}
-        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+set(CODE_LIB_NAME StarterProject.code)
+add_library(${CODE_LIB_NAME} INTERFACE)
+target_include_directories(${CODE_LIB_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LIB_NAME StarterProject.lib)
+add_library(${LIB_NAME} INTERFACE)
+target_include_directories(${LIB_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.8)
-project(StarterProject.tests)
+set(TEST_NAME StarterProject.tests)
 set(CMAKE_CXX_STANDARD 17)
 set(SOURCE_FILES
         main.cpp
         DemoTest.cpp
         NewTest.cpp
         Tutorial.cpp)
-add_executable(StarterProject.tests ${SOURCE_FILES} )
-add_test(NAME StarterProject.tests COMMAND StarterProject.tests)
+add_executable(${TEST_NAME} ${SOURCE_FILES})
+target_link_libraries(${TEST_NAME} StarterProject.code StarterProject.lib)
+add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})


### PR DESCRIPTION
**Description**
The goal of this pull request is to follow so called "Modern CMake" guidelines:
* Set dependencies and properties on targets directly using e.g. target_link_libraries
* Avoid setting global settings through e.g. include_directories

**Solution**
* Set project name and minimum CMake version in the top CMakelists.txt file only
* Add subdirectory lib using add_subdirectoy instead of via include_directories
* Add CMakeLists.txt file to lib folder
* Use command target_link_libraries in the tests folder to link tests with libraries defined in the code and lib folders